### PR TITLE
Fix type hinting in HttpResponse

### DIFF
--- a/lib/PayPalHttp/HttpResponse.php
+++ b/lib/PayPalHttp/HttpResponse.php
@@ -16,7 +16,7 @@ class HttpResponse
     public $statusCode;
 
     /**
-     * @var array | string
+     * @var array | string | object
      */
     public $result;
 


### PR DESCRIPTION
$body parameter in the constructor can be a json_decode() return, that is an object. $result is not annotated as such.
