### PR TITLE
Hdl 285 paypal sdk header: Fixing Case Sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 1.0.1
+* Fix Case Sensitivity of Content Type for deserialization process
+
 ## 1.0.0
 - First release

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2016 PayPal, Inc.
+Copyright (c) 2009-2021 PayPal, Inc.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/lib/PayPalHttp/Encoder.php
+++ b/lib/PayPalHttp/Encoder.php
@@ -70,6 +70,7 @@ class Encoder
         }
 
         $contentType = $headers['content-type'];
+        $contentType = strtolower($contentType);
         /** @var Serializer $serializer */
         $serializer = $this->serializer($contentType);
 

--- a/lib/PayPalHttp/HttpClient.php
+++ b/lib/PayPalHttp/HttpClient.php
@@ -110,7 +110,11 @@ class HttpClient
      * @return array
      */
     public function prepareHeaders($headers){
-        return array_change_key_case($headers);
+        $preparedHeaders = array_change_key_case($headers);
+        if (array_key_exists("content-type", $preparedHeaders)) {
+            $preparedHeaders["content-type"] = strtolower($preparedHeaders["content-type"]);
+        }
+        return $preparedHeaders;
     }
 
     /**

--- a/tests/unit/EncoderTest.php
+++ b/tests/unit/EncoderTest.php
@@ -139,6 +139,20 @@ class EncoderTest extends TestCase
         $this->assertEquals(["one", "two"], $result->key_two);
     }
 
+    public function testDecode_deserializesResponseWithContentEncodingCaseInsensitive()
+    {
+        $encoder = new Encoder();
+        $responseBody = '{"key_one":"value_one","key_two":["one","two"]}';
+        $headers = [
+            "content-type" => "application/JSON; charset=utf-8"
+        ];
+
+        $result = $encoder->deserializeResponse($responseBody, $headers);
+
+        $this->assertEquals("value_one", $result->key_one);
+        $this->assertEquals(["one", "two"], $result->key_two);
+    }
+
     public function testDecode_ungzipsDataWhenHeaderPresent()
     {
         $encoder = new Encoder();

--- a/tests/unit/HttpClientTest.php
+++ b/tests/unit/HttpClientTest.php
@@ -92,6 +92,25 @@ class HttpClientTest extends TestCase
             ->withRequestBody(WireMock::equalTo("some data")));
     }
 
+    public function testExecute_formsRequestProperlyCaseInsensitive()
+    {
+        $this->wireMock->stubFor(WireMock::post(WireMock::urlEqualTo("/path"))
+            ->willReturn(WireMock::aResponse()
+            ->withStatus(200)));
+
+        $client = new HttpClient($this->environment);
+
+        $req = new HttpRequest("/path", "POST");
+        $req->headers["Content-Type"] = "TEXT/plain";
+        $req->body = "some data";
+
+        $client->execute($req);
+
+        $this->wireMock->verify(WireMock::postRequestedFor(WireMock::urlEqualTo("/path"))
+            ->withHeader("Content-Type", WireMock::equalTo("text/plain"))
+            ->withRequestBody(WireMock::equalTo("some data")));
+    }
+
     public function testExecute_setsUserAgentIfNotSet()
     {
         $this->wireMock->stubFor(WireMock::post(WireMock::urlEqualTo("/path"))

--- a/tests/unit/Serializer/FormTest.php
+++ b/tests/unit/Serializer/FormTest.php
@@ -18,7 +18,7 @@ class FormTest extends TestCase
 
         $request = new HttpRequest("/", "POST");
         $request->body = "";
-        $request->headers["content-type"] = "application/x-www-form-urlencoded";
+        $request->headers["Content-Type"] = "application/x-www-form-urlencoded";
 
         $multipart->encode($request);
     }

--- a/tests/unit/Serializer/MultipartTest.php
+++ b/tests/unit/Serializer/MultipartTest.php
@@ -20,7 +20,7 @@ class MultipartTest extends TestCase
 
         $request = new HttpRequest("/", "POST");
         $request->body = "";
-        $request->headers["Content-Type"] = "multipart/form-data";
+        $request->headers["content-type"] = "multipart/form-data";
 
         $multipart->encode($request);
     }
@@ -39,7 +39,7 @@ class MultipartTest extends TestCase
 
         $request = new HttpRequest("/", "POST");
         $request->body = $body;
-        $request->headers["Content-Type"] = "multipart/form-data";
+        $request->headers["content-type"] = "multipart/form-data";
 
         $multipart->encode($request);
     }
@@ -105,7 +105,7 @@ class MultipartTest extends TestCase
 
         $request = new HttpRequest("/", "POST");
         $request->body = $body;
-        $request->headers["Content-Type"] = "multipart/form-data";
+        $request->headers["content-type"] = "multipart/form-data";
 
         $encodedBody = $multipart->encode($request);
         $this->assertContains("boundary=", $request->headers["content-type"]);


### PR DESCRIPTION
Internal Change for Ticket 285: 

Author: hlahlou

Changes made in Encoder and HttpClient to force the value for Content-Type to lowercase.

Added Unit Tests to ensure that deserialization and execution of HTTP request were case insensitive and could handle Content-Types of different casing (ex: application/json vs application/JSON)

Also updated the license, change log, and version to reflect changes made and to update copyright.


Results of Unit Tests:
<img width="1782" alt="Screen Shot 2021-08-25 at 1 11 21 PM" src="https://user-images.githubusercontent.com/30755392/130838887-93cfb4da-b72e-4b99-ad2d-42b3600d5654.png">


Something worthy to note, corrections to other Unit Tests were necessary to prevent errors inherit to the master branch. Before making any changes to the master branch, these below unit tests were throwing errors. This is due to the constant changing of the expected key for the content-type, switching between "Content-Type" and "content-type". The RFC does say that this is case insensitive but there should be a standard convention for accessing this header like the other projects (who format the headers to lowercase to ensure proper access). Made changes to unit tests to prevent the throwing of errors but should any changes be made to the SDK itself regarding this issue?

<img width="736" alt="Screen Shot 2021-08-24 at 2 23 08 PM" src="https://user-images.githubusercontent.com/30755392/130839027-51178d68-7f8b-4843-99c0-9ed6053ce6bf.png">

Integration Test Results with Checkout SDK:
<img width="1792" alt="Screen Shot 2021-09-01 at 3 31 59 PM" src="https://user-images.githubusercontent.com/30755392/131736130-ee5bbf19-d6d7-44d3-aa65-a9e2e4b6422b.png">
