### PR TITLE
fixed @ CVE-2020-8130

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     public_suffix (3.0.0)
-    rake (12.1.0)
+    rake (12.3.3)
     releasinator (0.7.6)
       colorize (~> 0.7)
       configatron (~> 4.5)


### PR DESCRIPTION
## Descriptions
[Arbitrary Code Injection in rake] Affected versions of this project are vulnerable to Arbitrary Code Injection in Rake::FileList when supplying a filename that begins with the pipe character `|`.

**PoC by Mik Patient**
```
% ls -1 Gemfile Gemfile.lock poc_rake.rb vendor | touch evil.txt % bundle exec ruby poc_rake.rb ["poc_rake.rb", "Gemfile", "Gemfile.lock", "| touch evil.txt", "vendor"] poc_rake.rb:6:list.egrep(/something/) Error while processing 'vendor': Is a directory @ io_fillbuf - fd:7 vendor % ls -1 Gemfile Gemfile.lock evil.txt poc_rake.rb vendor | touch evil.txt
```
**Supporting Refferences:**
 * https://hackerone.com/reports/651518

## Impact
An attacker must deploy a file containing command names in the target environment, assuming that this attack is successful. If that would be a serious problem.