### PR TITLE
Removed unused curlCls propery for PHP 8.2 compatibility

### DIFF
--- a/lib/PayPalHttp/HttpClient.php
+++ b/lib/PayPalHttp/HttpClient.php
@@ -35,7 +35,6 @@ class HttpClient
     {
         $this->environment = $environment;
         $this->encoder = new Encoder();
-        $this->curlCls = Curl::class;
     }
 
     /**


### PR DESCRIPTION
Property curlCls is set but never referenced.  I believe this is an error. It is giving a depreciation warning in PHP 8.2.  It can safely deleted.