### PR TITLE
fixing - curlCls is deprecated

### DIFF
--- a/lib/PayPalHttp/HttpClient.php
+++ b/lib/PayPalHttp/HttpClient.php
@@ -26,6 +26,11 @@ class HttpClient
     public $encoder;
 
     /**
+     * @var Curl
+     */
+    public $curlCls;
+
+    /**
      * HttpClient constructor. Pass the environment you wish to make calls to.
      *
      * @param Environment $environment


### PR DESCRIPTION
Getting error:
Deprecated: Creation of dynamic property PayPalPayouts\Core\PayPalHttpClient::$curlCls is deprecated

paypalhttp/lib/PayPalHttp/HttpClient.php on line 38
```
function __construct(Environment $environment)
{
    $this->environment = $environment;
    $this->encoder = new Encoder();
    $this->curlCls = Curl::class;
}
```
